### PR TITLE
Fixes #9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import Request from './request'
 import Response from './response'
 
 export interface Options {
-  proxy?: boolean
+  [x: string]: any
   tls?: https.ServerOptions
 }
 

--- a/test/server/on.ts
+++ b/test/server/on.ts
@@ -8,37 +8,42 @@ import { createHttpServerStub, noop } from '../support'
 describe('server.on(event, listener)', () => {
   var stub
   var server
+  var wrapStub
+  var requestWrapper = () => {}
 
   beforeEach(() => {
-    stub = createHttpServerStub()
-    server = new Server(stub)
+    server = new Server(stub = createHttpServerStub())
+    wrapStub = sinon.stub(server, '_wrap')
+
+    wrapStub.withArgs('request', noop).returns(requestWrapper)
+    wrapStub.withArgs('checkContinue', noop).returns(requestWrapper)
+    wrapStub.withArgs('checkExpectation', noop).returns(requestWrapper)
   })
 
-  it('should register the listener', () => {
-    server.on('foo', noop)
-
-    assert(stub.on.calledOnceWith('foo', noop))
-  })
-
-  it('should wrap `request` listeners', () => {
-    var wrapStub = sinon.stub(server, '_wrap')
-    var wrapper = function _wrapper () {}
-
-    wrapStub.withArgs(noop).returns(wrapper)
-
+  it('should register the `request` listener', () => {
     server.on('request', noop)
 
-    assert(stub.on.calledOnceWith('request', wrapper))
+    assert(stub.on.calledOnceWith('request', requestWrapper))
   })
 
-  it('should not wrap other event listeners', () => {
-    var wrapStub = sinon.stub(server, '_wrap')
-    var wrapper = function _wrapper () {}
+  it('should wrap `checkContinue` listeners', () => {
+    server.on('checkContinue', noop)
 
-    wrapStub.withArgs(noop).returns(wrapper)
+    assert(stub.on.calledOnceWith('checkContinue', requestWrapper))
+  })
 
+  it('should wrap `checkExpectation` listeners', () => {
+    server.on('checkExpectation', noop)
+
+    assert(stub.on.calledOnceWith('checkExpectation', requestWrapper))
+  })
+
+  it('should wrap any event listeners', () => {
+    var anyWrapper = () => {}
+
+    wrapStub.withArgs('foo', noop).returns(anyWrapper)
     server.on('foo', noop)
 
-    assert(stub.on.calledOnceWith('foo', noop))
+    assert(stub.on.calledOnceWith('foo', anyWrapper))
   })
 })


### PR DESCRIPTION
- Wrap `checkContinue` and `checkExpectation` in addition to the `request` event
- Defer any listener with `setImmediate`